### PR TITLE
Fix apply  dupulicate escaping html

### DIFF
--- a/lib/secret_console/views/layout.haml
+++ b/lib/secret_console/views/layout.haml
@@ -9,4 +9,4 @@
 
       .row
         .col-md-12
-          = yield
+          != yield


### PR DESCRIPTION
Displayed html code on view if use latest version of  haml 6.1.1.
I think this problem caused by this commit https://github.com/haml/haml/commit/08098f1b0f7709ba92aecc8cafbdf69d0f0cc5c5.
